### PR TITLE
Add header for ABKClassicImageContentCardCell.h

### DIFF
--- a/Sources/BrazeUICompat/ABKContentCards/AppboyContentCards.h
+++ b/Sources/BrazeUICompat/ABKContentCards/AppboyContentCards.h
@@ -7,3 +7,4 @@
 #import "ABKBaseContentCardCell.h"
 #import "ABKCaptionedImageContentCardCell.h"
 #import "ABKClassicContentCardCell.h"
+#import "ABKClassicImageContentCardCell.h"


### PR DESCRIPTION
After upgrading to the latest version, I encountered difficulty in building my project. Subsequent investigation revealed that ABKClassicImageContentCardCell is not exposed and cannot be accessed outside of the package.