### PR TITLE
Pin `SDWebImage` to version 5.21.0 to avoid broken 5.21.1 release

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/SDWebImage/SDWebImage.git", from: "5.19.7"),
+    .package(url: "https://github.com/SDWebImage/SDWebImage.git", exact: "5.21.0"),
     /* ${dependencies-start} */
     /* ${dependencies-end} */
   ],


### PR DESCRIPTION
This PR pins `SDWebImage` to version 5.21.0 to avoid build failures caused by the latest release (5.21.1), which is currently broken and causes SwiftPM resolution issues due to an invalid fingerprint.

See issue details here:
🔗 https://github.com/SDWebImage/SDWebImage/issues/3820
