### PR TITLE
Clear in-app message stack on user change to prevent stale WebView crashes

### DIFF
--- a/Sources/BrazeUI/InAppMessageUI/InAppMessageUI.swift
+++ b/Sources/BrazeUI/InAppMessageUI/InAppMessageUI.swift
@@ -130,11 +130,35 @@ open class BrazeInAppMessageUI:
   public func dismiss(reason: Braze.InAppMessage.DismissalReason) {
     switch reason {
     case .wipeData, .changeUser:
-      // Clear internal state
+      // Clear internal state — must happen before dismissal so that no stale messages
+      // are re-presented via presentFollowup() or presentNext() during teardown.
       stack.removeAll()
       localAssetsCancellable = nil
       isProcessingClickAction = false
       followupMessage = nil
+
+      // Invalidate the dismiss timer immediately to prevent it from firing during or
+      // after the teardown (the normal path only invalidates in didDismiss()).
+      dismissTimer?.invalidate()
+      dismissTimer = nil
+
+      // Tear down the window synchronously. HTML in-app messages hold a WebView whose
+      // ScriptMessageHandler references the now-invalidated Braze context. Relying on
+      // the animated dismiss path leaves a window where the WebView can invoke its
+      // bridge handler against a stale context, causing EXC_BREAKPOINT.
+      // See: https://github.com/braze-inc/braze-swift-sdk/issues/191
+      if let window {
+        window.messageViewController?.messageView.dismiss(completion: nil)
+        window.rootViewController = nil
+        if #available(iOS 13.0, *) {
+          window.windowScene = nil
+        }
+        window.isHidden = true
+        self.window = nil
+        _ = try? resetAssetsDirectory()
+      }
+      return
+
     @unknown default:
       break
     }


### PR DESCRIPTION
## Summary

- Fixes a crash (EXC_BREAKPOINT) when HTML in-app messages are re-presented after `changeUser()` invalidates the Braze context
- Tears down the IAM window and WebView synchronously during `dismiss(reason: .changeUser)` instead of relying on the async animated dismiss path
- Invalidates the dismiss timer immediately to prevent it firing during teardown

## Problem

When an HTML in-app message is displayed or queued (via `.reenqueue`) and `changeUser()` is called:

1. The stale message's `ScriptMessageHandler` / WebView bridge holds a reference to the now-invalidated `Braze.InAppMessage.Context`
2. The existing `dismiss(reason:)` clears the stack and followup but delegates actual window teardown to the **animated** `dismiss(completion:)` path
3. During the animation window, the WebView can still invoke its bridge handler against the stale context
4. This causes `EXC_BREAKPOINT` — the `ScriptMessageHandler` traps when it finds the Braze instance has been released

**Crash trace:**
```
Thread 0 Crashed:
BrazeKit  Braze.InAppMessage.Context  (context is invalidated)
BrazeUI   ScriptMessageHandler.userContentController(_:didReceive:)
WebKit    WebKit::WebUserContentControllerProxy::didPostMessage
```

## Fix

In `BrazeInAppMessageUI.dismiss(reason:)`, for `.changeUser` and `.wipeData`:

1. **Invalidate the dismiss timer immediately** — previously only invalidated in `didDismiss()` after animation completion
2. **Tear down the window synchronously**: call `messageView.dismiss()`, nil out `rootViewController`, detach `windowScene`, hide the window, and clear the reference
3. **Return early** — skip the async `dismiss(completion:)` path entirely

This is a minimal, focused change to the `dismiss(reason:)` method in `BrazeInAppMessageUI`. No changes to BrazeKit.

## Test plan

- [ ] Trigger an HTML in-app message, then call `changeUser()` before dismissing — verify no crash
- [ ] Trigger an HTML in-app message with `.reenqueue` display choice, call `changeUser()`, then call `presentNext()` — verify empty stack, no crash
- [ ] Verify normal (non-changeUser) dismiss path is unchanged — animation still works
- [ ] Verify `.wipeData` also cleans up correctly

Fixes https://github.com/braze-inc/braze-swift-sdk/issues/191

🤖 Generated with [Claude Code](https://claude.com/claude-code)