### PR TITLE
Fix in-app message close button touch target to meet 44pt minimum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+##### Fixed
+- Fixes the Modal and Modal Image in-app message close button exposing a touch target smaller than the 44×44pt minimum recommended by WCAG 2.5.8 (Target Size) and the Apple Human Interface Guidelines. The close button now enforces a 44pt minimum width and height while keeping the glyph visually centered.
+
 ## 17.0.0
 
 ##### Breaking

--- a/Sources/BrazeUI/InAppMessageUI/Views/InAppMessageUIModalImageView.swift
+++ b/Sources/BrazeUI/InAppMessageUI/Views/InAppMessageUIModalImageView.swift
@@ -344,6 +344,8 @@ extension BrazeInAppMessageUI {
 
         // Close button
         closeButton.anchors.height.equal(closeButton.anchors.width)
+        // Enforce the 44pt minimum touch target (WCAG 2.5.8 Target Size, Apple HIG).
+        closeButton.anchors.width.greaterThanOrEqual(44)
         closeButton.anchors.edges.pin(
           to: contentView.layoutMarginsGuide,
           alignment: .topTrailing

--- a/Sources/BrazeUI/InAppMessageUI/Views/InAppMessageUIModalView.swift
+++ b/Sources/BrazeUI/InAppMessageUI/Views/InAppMessageUIModalView.swift
@@ -403,6 +403,8 @@ extension BrazeInAppMessageUI {
 
         // Close button
         closeButton.anchors.height.equal(closeButton.anchors.width)
+        // Enforce the 44pt minimum touch target (WCAG 2.5.8 Target Size, Apple HIG).
+        closeButton.anchors.width.greaterThanOrEqual(44)
         closeButton.anchors.edges.pin(to: contentView.layoutMarginsGuide, alignment: .topTrailing)
 
         // Content view


### PR DESCRIPTION
The Modal and Modal Image in-app message close buttons only constrained `height == width`, leaving the tap target at the intrinsic size of the 22pt "✕" glyph (~39x39pt) — below the 44x44pt minimum required by WCAG 2.5.8 (Target Size) and the Apple Human Interface Guidelines. Accessibility scanners flag the control at 39x39.

Add a required `width.greaterThanOrEqual(44)` constraint in both views. Since `height == width` is already enforced, this guarantees a >=44x44pt target while keeping the "✕" glyph visually centred. The required constraint overrides the default content-hugging priority, so the button grows from its intrinsic ~39pt to 44pt.

**Affected**: `InAppMessageUIModalImageView`, `InAppMessageUIModalView`. Slideup (chevron image) and the Full/Full Image views (no close button) are unaffected. Additive layout constraint only; no public API change.

<img width="500" alt="Unknown" src="https://github.com/user-attachments/assets/9043fdc8-737a-453c-b36a-55e5259ffd28" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Auto Layout constraints on two in-app message views only; no API or behavior changes beyond a slightly larger close-button hit area.
> 
> **Overview**
> Modal and Modal Image in-app message close buttons previously sized only from the intrinsic “✕” glyph (~39×39pt) because layout kept **height equal to width** without a floor, which failed WCAG 2.5.8 / Apple HIG **44×44pt** touch targets.
> 
> This change adds **`width.greaterThanOrEqual(44)`** alongside the existing square constraint in **`InAppMessageUIModalView`** and **`InAppMessageUIModalImageView`**, so the control is at least **44×44pt** while the glyph stays centered. **CHANGELOG** documents the fix under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4256a76c6b9a2389790579b21683ac424f4567a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->